### PR TITLE
TypeCheckingExercises

### DIFF
--- a/src/main/scala/shapeless/ShapelessLib.scala
+++ b/src/main/scala/shapeless/ShapelessLib.scala
@@ -24,6 +24,7 @@ object ShapelessLib extends exercise.Library {
     AutoTypeClassExercises,
     LazyExercises,
     SizedExercises,
-    TypeSafeCastExercises
+    TypeSafeCastExercises,
+    TypeCheckingExercises
   )
 }

--- a/src/main/scala/shapeless/TypeCheckingExercises.scala
+++ b/src/main/scala/shapeless/TypeCheckingExercises.scala
@@ -1,10 +1,7 @@
 package shapelessex
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
 import org.scalatest._
 import shapeless._
-import shapelessex.TypeCheckingExercises._
 
 import scala.util.Try
 

--- a/src/main/scala/shapeless/TypeCheckingExercises.scala
+++ b/src/main/scala/shapeless/TypeCheckingExercises.scala
@@ -1,0 +1,56 @@
+package shapelessex
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest._
+import shapeless._
+import shapelessex.TypeCheckingExercises._
+
+import scala.util.Try
+
+/** == Testing for non-compilation ==
+  *
+  * Libraries like shapeless which make extensive use of type-level computation and implicit resolution often need to
+  * provide guarantees that certain expressions *don't* typecheck. Testing these guarantees is supported in shapeless via
+  * the `illTyped` macro,
+  * {{{
+  * import shapeless.test.illTyped
+  *
+  * scala> illTyped { """1+1 : Boolean""" }
+  *
+  * scala> illTyped { """1+1 : Int""" }
+  * <console>:19: error: Type-checking succeeded unexpectedly.
+  * Expected some error.
+  * illTyped { """1+1 : Int""" }
+  * }}}
+  *
+  * @param name type_checking
+  */
+object TypeCheckingExercises extends FlatSpec with Matchers with exercise.Section {
+
+  /** The testing library ScalaTest also has a way of checking that a snippet of code
+    * does not compile: pass it in to `assertTypeError`. What will happen if we combine
+    * `illTyped` and `assertTypeError`? (Hint: it's like applying a double negative.)
+    */
+  def typeCheckingTest(res0: Boolean, res1: Boolean) = {
+
+    import shapeless.test.illTyped
+
+    val matchedTypes = Try {
+      assertTypeError("illTyped { \"val a: Int = 1\" }")
+      true
+    } getOrElse {
+      false
+    }
+    matchedTypes should be(res0)
+
+    val mismatchedTypes = Try {
+      assertTypeError("illTyped { \"val a: String = 1\" }")
+      true
+    } getOrElse {
+      false
+    }
+    mismatchedTypes should be(res1)
+  }
+
+}

--- a/src/test/scala/exercises/shapeless/TypeCheckingExercisesSpec.scala
+++ b/src/test/scala/exercises/shapeless/TypeCheckingExercisesSpec.scala
@@ -1,7 +1,12 @@
-package test.scala.exercises.shapeless
+package exercises
 
-import exercises.Test
-import shapelessex.TypeCheckingExercises
+import shapelessex._
+import shapeless.HNil
+
+import org.scalatest.Spec
+import org.scalatest.prop.Checkers
+
+import org.scalacheck.Shapeless._
 
 class TypeCheckingExercisesSpec extends Spec with Checkers {
   def `testing for non-compilation` = {

--- a/src/test/scala/exercises/shapeless/TypeCheckingExercisesSpec.scala
+++ b/src/test/scala/exercises/shapeless/TypeCheckingExercisesSpec.scala
@@ -1,0 +1,15 @@
+package test.scala.exercises.shapeless
+
+import exercises.Test
+import shapelessex.TypeCheckingExercises
+
+class TypeCheckingExercisesSpec extends Spec with Checkers {
+  def `testing for non-compilation` = {
+    check(
+      Test.testSuccess(
+        TypeCheckingExercises.typeCheckingTest _,
+        true :: false :: HNil
+      )
+    )
+  }
+}


### PR DESCRIPTION
This is an example of exercises that address the issue in scala-exercises/site#393.

The feature being demonstrated from Shapeless is `illTyped`. This causes an expression to fail at compile-time. The first part of text in the exercise is taken from @milessabin's classic documentation as with the rest of the exercises.

The tests use ScalaTest's `assertTypeError` which doesn't fail at compile-time but throws an exception, which I then convert to a Boolean. I think this technique could be useful for compile-time checking throughout the exercises, e.g. in the CSV parsing. However, you might want to refine it. For instance, you could write your own macro, similar to @bvenners `assertTypeError`, but returning a Boolean. Also feel free to change the text of this exercise in any way.

By the way, it would also be nice to have an exercise for Shapeless Nat (natural numbers).