### PR TITLE
Integrates sbt-org-policies plugin

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,23 @@
+style = defaultWithAlign
+maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,3 @@ after_success:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
      sbt compile publishSigned;
   fi
-- if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then
-     echo "Not in master branch, skipping deploy and release";
-  fi

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-#Scala Exercises - Shapeless
-
+# Scala Exercises - Shapeless
 ------------------------
 
 This repository hosts a content library for the [Scala Exercises](https://www.scala-exercises.org/) platform, including interactive exercises related to the [Shapeless](https://github.com/milessabin/shapeless) generic programming library.
 
-## About Scala exercises
+## About Scala exercises
 
 "Scala Exercises" brings exercises for the Stdlib, Cats, Shapeless and many other great libraries for Scala to your browser. Offering hundreds of solvable exercises organized into several categories covering the basics of the Scala language and it's most important libraries.
 
@@ -15,7 +14,7 @@ Scala Exercises is available at [scala-exercises.org](https://scala-exercises.or
 Contributions welcome! Please join our [Gitter channel](https://gitter.im/scala-exercises/scala-exercises)
 to get involved, or visit our [GitHub site](https://github.com/scala-exercises).
 
-##License
+## License
 
 Copyright (C) 2015-2016 47 Degrees, LLC.
 Reactive, scalable software solutions.

--- a/build.sbt
+++ b/build.sbt
@@ -1,51 +1,23 @@
+val scalaExerciesV = "0.4.0-SNAPSHOT"
+
+def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExerciesV
+
 lazy val shapeless = (project in file("."))
-.settings(publishSettings:_*)
-.enablePlugins(ExerciseCompilerPlugin)
-.settings(
-  organization := "org.scala-exercises",
-  name         := "exercises-shapeless",
-  scalaVersion := "2.11.8",
-  version := "0.3.0-SNAPSHOT",
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
-  ),
-  libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-core" % "0.7.2",
-    "com.chuusai" %% "shapeless" % "2.2.5",
-    "org.scalatest" %% "scalatest" % "2.2.4",
-    "org.scala-exercises" %% "exercise-compiler" % version.value,
-    "org.scala-exercises" %% "definitions" % version.value,
-    "org.scalacheck" %% "scalacheck" % "1.12.5",
-    "com.github.alexarchambault" %% "scalacheck-shapeless_1.12" % "0.3.1",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.0")
+  .enablePlugins(ExerciseCompilerPlugin)
+  .settings(
+    name         := "exercises-shapeless",
+    libraryDependencies ++= Seq(
+      dep("exercise-compiler"),
+      dep("definitions"),
+      %%("shapeless"),
+      %%("scalatest"),
+      %%("scalacheck"),
+      %%("scheckShapeless")
+    )
   )
-)
 
 // Distribution
 
-lazy val gpgFolder = sys.env.getOrElse("PGP_FOLDER", ".")
-
-lazy val publishSettings = Seq(
-  organizationName := "Scala Exercises",
-  organizationHomepage := Some(new URL("http://scala-exercises.org")),
-  startYear := Some(2016),
-  description := "Scala Exercises: The path to enlightenment",
-  homepage := Some(url("http://scala-exercises.org")),
-  pgpPassphrase := Some(sys.env.getOrElse("PGP_PASSPHRASE", "").toCharArray),
-  pgpPublicRing := file(s"$gpgFolder/pubring.gpg"),
-  pgpSecretRing := file(s"$gpgFolder/secring.gpg"),
-  credentials += Credentials("Sonatype Nexus Repository Manager",  "oss.sonatype.org",  sys.env.getOrElse("PUBLISH_USERNAME", ""),  sys.env.getOrElse("PUBLISH_PASSWORD", "")),
-  scmInfo := Some(ScmInfo(url("https://github.com/scala-exercises/exercises-shapeless"), "https://github.com/scala-exercises/exercises-shapeless.git")),
-  licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-  publishMavenStyle := true,
-  publishArtifact in Test := false,
-  pomIncludeRepository := Function.const(false),
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("Snapshots" at nexus + "content/repositories/snapshots")
-    else
-      Some("Releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-)
+pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray)
+pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
+pgpSecretRing := file(s"$gpgFolder/secring.gpg")

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,0 +1,47 @@
+import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbtorgpolicies._
+import sbtorgpolicies.model._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
+
+object ProjectPlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] =
+    Seq(
+      description := "Scala Exercises: The path to enlightenment",
+      startYear := Option(2016),
+      orgGithubSetting := GitHubSettings(
+        organization = "scala-exercises",
+        project = name.value,
+        organizationName = "Scala Exercises",
+        groupId = "org.scala-exercises",
+        organizationHomePage = url("https://www.scala-exercises.org"),
+        organizationEmail = "hello@47deg.com"
+      ),
+      orgLicenseSetting := ApacheLicense,
+      scalaVersion := "2.11.8",
+      scalaOrganization := "org.scala-lang",
+      crossScalaVersions := Seq("2.11.8"),
+      resolvers ++= Seq(
+        Resolver.mavenLocal,
+        Resolver.sonatypeRepo("snapshots"),
+        Resolver.sonatypeRepo("releases")
+      ),
+      scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
+      headers := Map(
+        "scala" -> (HeaderPattern.cStyleBlockComment,
+          s"""|/*
+              | * scala-exercises - ${name.value}
+              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+              | */
+              |
+            |""".stripMargin)
+      )
+    )
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.3.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.3.2")

--- a/src/main/scala/shapeless/ArityExercises.scala
+++ b/src/main/scala/shapeless/ArityExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -7,31 +12,32 @@ import ops.function._
 import syntax.std.function._
 
 object Helper {
-  def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)(implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L ⇒ R]) =
+  def applyProduct[P <: Product, F, L <: HList, R](p: P)(
+      f: F)(implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L ⇒ R]) =
     f.toProduct(gen.to(p))
 }
 
 /** == Facilities for abstracting over arity ==
-  *
-  * Conversions between tuples and `HList`'s, and between ordinary Scala functions of arbitrary arity and functions which
-  * take a single corresponding `HList` argument allow higher order functions to abstract over the arity of the functions
-  * and values they are passed
-  * {{{
-  * import syntax.std.function._
-  * import ops.function._
-  *
-  * def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)
-  * (implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L => R]) =
-  * f.toProduct(gen.to(p))
-  * }}}
-  *
-  * @param name arity
-  */
+ *
+ * Conversions between tuples and `HList`'s, and between ordinary Scala functions of arbitrary arity and functions which
+ * take a single corresponding `HList` argument allow higher order functions to abstract over the arity of the functions
+ * and values they are passed
+ * {{{
+ * import syntax.std.function._
+ * import ops.function._
+ *
+ * def applyProduct[P <: Product, F, L <: HList, R](p: P)(f: F)
+ * (implicit gen: Generic.Aux[P, L], fp: FnToProduct.Aux[F, L => R]) =
+ * f.toProduct(gen.to(p))
+ * }}}
+ *
+ * @param name arity
+ */
 object ArityExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
   import Helper._
 
   /** Abstracting over arity
-    */
+   */
   def arityTest(res0: Int, res1: Int) = {
     applyProduct(1, 2)((_: Int) + (_: Int)) should be(res0)
     applyProduct(1, 2, 3)((_: Int) * (_: Int) * (_: Int)) should be(res1)

--- a/src/main/scala/shapeless/AutoTypeClassExercises.scala
+++ b/src/main/scala/shapeless/AutoTypeClassExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -12,38 +17,38 @@ object Monoid extends ProductTypeClassCompanion[Monoid] {
   def mzero[T](implicit mt: Monoid[T]) = mt.zero
 
   implicit def booleanMonoid: Monoid[Boolean] = new Monoid[Boolean] {
-    def zero = false
+    def zero                           = false
     def append(a: Boolean, b: Boolean) = a || b
   }
 
   implicit def intMonoid: Monoid[Int] = new Monoid[Int] {
-    def zero = 0
+    def zero                   = 0
     def append(a: Int, b: Int) = a + b
   }
 
   implicit def doubleMonoid: Monoid[Double] = new Monoid[Double] {
-    def zero = 0.0
+    def zero                         = 0.0
     def append(a: Double, b: Double) = a + b
   }
 
   implicit def stringMonoid: Monoid[String] = new Monoid[String] {
-    def zero = ""
+    def zero                         = ""
     def append(a: String, b: String) = a + b
   }
 
   object typeClass extends ProductTypeClass[Monoid] {
     def emptyProduct = new Monoid[HNil] {
-      def zero = HNil
+      def zero                     = HNil
       def append(a: HNil, b: HNil) = HNil
     }
 
     def product[F, T <: HList](mh: Monoid[F], mt: Monoid[T]) = new Monoid[F :: T] {
-      def zero = mh.zero :: mt.zero
+      def zero                         = mh.zero :: mt.zero
       def append(a: F :: T, b: F :: T) = mh.append(a.head, b.head) :: mt.append(a.tail, b.tail)
     }
 
     def project[F, G](instance: ⇒ Monoid[G], to: F ⇒ G, from: G ⇒ F) = new Monoid[F] {
-      def zero = from(instance.zero)
+      def zero               = from(instance.zero)
       def append(a: F, b: F) = from(instance.append(to(a), to(b)))
     }
   }
@@ -54,89 +59,93 @@ trait MonoidSyntax[T] {
 }
 
 object MonoidSyntax {
-  implicit def monoidSyntax[T](a: T)(implicit mt: Monoid[T]): MonoidSyntax[T] = new MonoidSyntax[T] {
-    def |+|(b: T) = mt.append(a, b)
-  }
+  implicit def monoidSyntax[T](a: T)(implicit mt: Monoid[T]): MonoidSyntax[T] =
+    new MonoidSyntax[T] {
+      def |+|(b: T) = mt.append(a, b)
+    }
 }
 
 /** == Automatic type class instance derivation ==
-  *
-  * Based on and extending `Generic` and `LabelledGeneric`, Lars Hupel ([[https://twitter.com/larsr_h @larsr_h]]) has contributed the `TypeClass`
-  * family of type classes, which provide automatic type class derivation facilities roughly equivalent to those available
-  * with GHC as described in [[http://dreixel.net/research/pdf/gdmh.pdf "A Generic Deriving Mechanism for Haskell"]].  There is a description of an
-  * earlier iteration of the Scala mechanism [[http://typelevel.org/blog/2013/06/24/deriving-instances-1.html here]], and examples of its use deriving `Show` and `Monoid`
-  * instances [[https://github.com/milessabin/shapeless/blob/master/examples/src/main/scala/shapeless/examples/shows.scala here]]
-  * and [[https://github.com/milessabin/shapeless/blob/master/examples/src/main/scala/shapeless/examples/monoids.scala here]] for labelled coproducts and unlabelled products respectively.
-  *
-  * For example, in the `Monoid` case, once the general deriving infrastructure for monoids is in place, instances are
-  * automatically available for arbitrary case classes without any additional boilerplate
-  *
-  * {{{
-  * trait Monoid[T] {
-  * def zero: T
-  * def append(a: T, b: T): T
-  * }
-  *
-  * object Monoid extends ProductTypeClassCompanion[Monoid] {
-  * def mzero[T](implicit mt: Monoid[T]) = mt.zero
-  *
-  * implicit def booleanMonoid: Monoid[Boolean] = new Monoid[Boolean] {
-  * def zero = false
-  * def append(a: Boolean, b: Boolean) = a || b
-  * }
-  *
-  * implicit def intMonoid: Monoid[Int] = new Monoid[Int] {
-  * def zero = 0
-  * def append(a: Int, b: Int) = a+b
-  * }
-  *
-  * implicit def doubleMonoid: Monoid[Double] = new Monoid[Double] {
-  * def zero = 0.0
-  * def append(a: Double, b: Double) = a+b
-  * }
-  *
-  * implicit def stringMonoid: Monoid[String] = new Monoid[String] {
-  * def zero = ""
-  * def append(a: String, b: String) = a+b
-  * }
-  *
-  * object typeClass extends ProductTypeClass[Monoid] {
-  * def emptyProduct = new Monoid[HNil] {
-  * def zero = HNil
-  * def append(a: HNil, b: HNil) = HNil
-  * }
-  *
-  * def product[F, T <: HList](mh: Monoid[F], mt: Monoid[T]) = new Monoid[F :: T] {
-  * def zero = mh.zero :: mt.zero
-  * def append(a: F :: T, b: F :: T) = mh.append(a.head, b.head) :: mt.append(a.tail, b.tail)
-  * }
-  *
-  * def project[F, G](instance: => Monoid[G], to: F => G, from: G => F) = new Monoid[F] {
-  * def zero = from(instance.zero)
-  * def append(a: F, b: F) = from(instance.append(to(a), to(b)))
-  * }
-  * }
-  * }
-  *
-  * trait MonoidSyntax[T] {
-  * def |+|(b: T): T
-  * }
-  *
-  * object MonoidSyntax {
-  * implicit def monoidSyntax[T](a: T)(implicit mt: Monoid[T]): MonoidSyntax[T] = new MonoidSyntax[T] {
-  * def |+|(b: T) = mt.append(a, b)
-  * }
-  * }
-  * }}}
-  * The [[https://github.com/typelevel/shapeless-contrib shapeless-contrib]] project also contains automatically derived type class instances for
-  * [[https://github.com/typelevel/shapeless-contrib/blob/master/scalaz/main/scala/typeclass.scala Scalaz]],
-  * [[https://github.com/typelevel/shapeless-contrib/blob/master/spire/main/scala/typeclass.scala Spire]] and
-  * [[https://github.com/typelevel/shapeless-contrib/blob/master/scalacheck/main/scala/package.scala Scalacheck]].
-  *
-  * @param name auto_typeclass_derivation
-  *
-  */
-object AutoTypeClassExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * Based on and extending `Generic` and `LabelledGeneric`, Lars Hupel ([[https://twitter.com/larsr_h @larsr_h]]) has contributed the `TypeClass`
+ * family of type classes, which provide automatic type class derivation facilities roughly equivalent to those available
+ * with GHC as described in [[http://dreixel.net/research/pdf/gdmh.pdf "A Generic Deriving Mechanism for Haskell"]].  There is a description of an
+ * earlier iteration of the Scala mechanism [[http://typelevel.org/blog/2013/06/24/deriving-instances-1.html here]], and examples of its use deriving `Show` and `Monoid`
+ * instances [[https://github.com/milessabin/shapeless/blob/master/examples/src/main/scala/shapeless/examples/shows.scala here]]
+ * and [[https://github.com/milessabin/shapeless/blob/master/examples/src/main/scala/shapeless/examples/monoids.scala here]] for labelled coproducts and unlabelled products respectively.
+ *
+ * For example, in the `Monoid` case, once the general deriving infrastructure for monoids is in place, instances are
+ * automatically available for arbitrary case classes without any additional boilerplate
+ *
+ * {{{
+ * trait Monoid[T] {
+ * def zero: T
+ * def append(a: T, b: T): T
+ * }
+ *
+ * object Monoid extends ProductTypeClassCompanion[Monoid] {
+ * def mzero[T](implicit mt: Monoid[T]) = mt.zero
+ *
+ * implicit def booleanMonoid: Monoid[Boolean] = new Monoid[Boolean] {
+ * def zero = false
+ * def append(a: Boolean, b: Boolean) = a || b
+ * }
+ *
+ * implicit def intMonoid: Monoid[Int] = new Monoid[Int] {
+ * def zero = 0
+ * def append(a: Int, b: Int) = a+b
+ * }
+ *
+ * implicit def doubleMonoid: Monoid[Double] = new Monoid[Double] {
+ * def zero = 0.0
+ * def append(a: Double, b: Double) = a+b
+ * }
+ *
+ * implicit def stringMonoid: Monoid[String] = new Monoid[String] {
+ * def zero = ""
+ * def append(a: String, b: String) = a+b
+ * }
+ *
+ * object typeClass extends ProductTypeClass[Monoid] {
+ * def emptyProduct = new Monoid[HNil] {
+ * def zero = HNil
+ * def append(a: HNil, b: HNil) = HNil
+ * }
+ *
+ * def product[F, T <: HList](mh: Monoid[F], mt: Monoid[T]) = new Monoid[F :: T] {
+ * def zero = mh.zero :: mt.zero
+ * def append(a: F :: T, b: F :: T) = mh.append(a.head, b.head) :: mt.append(a.tail, b.tail)
+ * }
+ *
+ * def project[F, G](instance: => Monoid[G], to: F => G, from: G => F) = new Monoid[F] {
+ * def zero = from(instance.zero)
+ * def append(a: F, b: F) = from(instance.append(to(a), to(b)))
+ * }
+ * }
+ * }
+ *
+ * trait MonoidSyntax[T] {
+ * def |+|(b: T): T
+ * }
+ *
+ * object MonoidSyntax {
+ * implicit def monoidSyntax[T](a: T)(implicit mt: Monoid[T]): MonoidSyntax[T] = new MonoidSyntax[T] {
+ * def |+|(b: T) = mt.append(a, b)
+ * }
+ * }
+ * }}}
+ * The [[https://github.com/typelevel/shapeless-contrib shapeless-contrib]] project also contains automatically derived type class instances for
+ * [[https://github.com/typelevel/shapeless-contrib/blob/master/scalaz/main/scala/typeclass.scala Scalaz]],
+ * [[https://github.com/typelevel/shapeless-contrib/blob/master/spire/main/scala/typeclass.scala Spire]] and
+ * [[https://github.com/typelevel/shapeless-contrib/blob/master/scalacheck/main/scala/package.scala Scalacheck]].
+ *
+ * @param name auto_typeclass_derivation
+ *
+ */
+object AutoTypeClassExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   object Helper {
 
@@ -148,13 +157,13 @@ object AutoTypeClassExercises extends FlatSpec with Matchers with org.scalaexerc
   import Helper._
 
   /** {{{
-    *
-    * // A pair of arbitrary case classes
-    * case class Foo(i : Int, s : String)
-    * case class Bar(b : Boolean, s : String, d : Double)
-    *
-    * }}}
-    */
+   *
+   * // A pair of arbitrary case classes
+   * case class Foo(i : Int, s : String)
+   * case class Bar(b : Boolean, s : String, d : Double)
+   *
+   * }}}
+   */
   def monoidDerivation(res0: Int, res1: String, res2: Boolean, res3: String, res4: Double) = {
 
     import MonoidSyntax._

--- a/src/main/scala/shapeless/CoproductExercises.scala
+++ b/src/main/scala/shapeless/CoproductExercises.scala
@@ -1,24 +1,32 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == Coproducts and discriminated unions ==
-  *
-  * shapeless has a Coproduct type, a generalization of Scala's `Either` to an arbitrary number of choices. Currently it
-  * exists primarily to support `Generic` (see the next section), but will be expanded analogously to `HList` in later
-  * releases. Currently `Coproduct` supports mapping, selection and unification
-  *
-  * @param name coproducts
-  */
-object CoproductExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * shapeless has a Coproduct type, a generalization of Scala's `Either` to an arbitrary number of choices. Currently it
+ * exists primarily to support `Generic` (see the next section), but will be expanded analogously to `HList` in later
+ * releases. Currently `Coproduct` supports mapping, selection and unification
+ *
+ * @param name coproducts
+ */
+object CoproductExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   object Helper {
     type ISB = Int :+: String :+: Boolean :+: CNil
 
     object sizeM extends Poly1 {
-      implicit def caseInt = at[Int](i ⇒ (i, i))
-      implicit def caseString = at[String](s ⇒ (s, s.length))
+      implicit def caseInt     = at[Int](i ⇒ (i, i))
+      implicit def caseString  = at[String](s ⇒ (s, s.length))
       implicit def caseBoolean = at[Boolean](b ⇒ (b, 1))
     }
 
@@ -28,11 +36,11 @@ object CoproductExercises extends FlatSpec with Matchers with org.scalaexercises
   import Helper._
 
   /** {{{
-    * type ISB = Int :+: String :+: Boolean :+: CNil
-    *
-    * val isb = Coproduct[ISB]("foo")
-    * }}}
-    */
+   * type ISB = Int :+: String :+: Boolean :+: CNil
+   *
+   * val isb = Coproduct[ISB]("foo")
+   * }}}
+   */
   def selection(res0: Option[Int], res1: Option[String]) = {
     isb.select[Int] should be(res0)
 
@@ -40,14 +48,14 @@ object CoproductExercises extends FlatSpec with Matchers with org.scalaexercises
   }
 
   /** Coproduct also supports mapping given a polymorphic function such as
-    * {{{
-    * object sizeM extends Poly1 {
-    * implicit def caseInt = at[Int](i => (i, i))
-    * implicit def caseString = at[String](s => (s, s.length))
-    * implicit def caseBoolean = at[Boolean](b => (b, 1))
-    * }
-    * }}}
-    */
+   * {{{
+   * object sizeM extends Poly1 {
+   * implicit def caseInt = at[Int](i => (i, i))
+   * implicit def caseString = at[String](s => (s, s.length))
+   * implicit def caseBoolean = at[Boolean](b => (b, 1))
+   * }
+   * }}}
+   */
   def mapping(res0: Option[(String, Int)]) = {
     val m = isb map sizeM
 
@@ -55,8 +63,8 @@ object CoproductExercises extends FlatSpec with Matchers with org.scalaexercises
   }
 
   /** In the same way that adding labels To the elements of an HList gives us a record,
-    * adding labels to the elements of a Coproduct gives us a discriminated union.
-    */
+   * adding labels to the elements of a Coproduct gives us a discriminated union.
+   */
   def unionE(res0: Option[Int], res1: Option[String], res2: Option[Boolean]) = {
     import record._, union._, syntax.singleton._
 

--- a/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
+++ b/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -5,26 +10,29 @@ import shapeless._
 import ops.hlist._
 
 /** == Extensible records ==
-  *
-  * shapeless provides an implementation of extensible records modelled as `HLists` of values tagged with the singleton
-  * types of their keys. This means that there is no concrete representation needed at all for the keys. Amongst other
-  * things this will allow subsequent work on `Generic` to map case classes directly to records with their member names
-  * encoded in their element types.
-  * {{{
-  * import shapeless._ ; import syntax.singleton._ ; import record._
-  *
-  * val book =
-  * ("author" ->> "Benjamin Pierce") ::
-  * ("title"  ->> "Types and Programming Languages") ::
-  * ("id"     ->>  262162091) ::
-  * ("price"  ->>  44.11) ::
-  * HNil
-  * }}}
-  *
-  * @param name extensible_records
-  *
-  */
-object ExtensibleRecordsExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * shapeless provides an implementation of extensible records modelled as `HLists` of values tagged with the singleton
+ * types of their keys. This means that there is no concrete representation needed at all for the keys. Amongst other
+ * things this will allow subsequent work on `Generic` to map case classes directly to records with their member names
+ * encoded in their element types.
+ * {{{
+ * import shapeless._ ; import syntax.singleton._ ; import record._
+ *
+ * val book =
+ * ("author" ->> "Benjamin Pierce") ::
+ * ("title"  ->> "Types and Programming Languages") ::
+ * ("id"     ->>  262162091) ::
+ * ("price"  ->>  44.11) ::
+ * HNil
+ * }}}
+ *
+ * @param name extensible_records
+ *
+ */
+object ExtensibleRecordsExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   import shapeless._; import syntax.singleton._; import record._
 
@@ -36,7 +44,7 @@ object ExtensibleRecordsExercises extends FlatSpec with Matchers with org.scalae
       HNil
 
   /**
-    */
+   */
   def resultTypes(res0: String, res1: String, res2: Int, res3: Double) = {
     book("author") should be(res0)
     book("title") should be(res1)
@@ -46,22 +54,21 @@ object ExtensibleRecordsExercises extends FlatSpec with Matchers with org.scalae
 
   /*
   /** Keys are materialized from singleton types encoded in value type
-    */
+   */
   def keys(res0 : ?) = {
     book.keys should be (res0)
   }
    */
   /** values
-    */
-  def values(res0: String :: String :: Int :: Double :: HNil) = {
+   */
+  def values(res0: String :: String :: Int :: Double :: HNil) =
     book.values should be(res0)
-  }
 
   /** Update, Add or remove a field
-    */
+   */
   def updated(res0: Double, res1: Boolean, res2: String :: String :: Double :: Boolean :: HNil) = {
     val newPrice = book("price") + 2.0
-    val updated = book + ("price" ->> newPrice)
+    val updated  = book + ("price" ->> newPrice)
 
     updated("price") should be(res0)
 

--- a/src/main/scala/shapeless/GenericExercises.scala
+++ b/src/main/scala/shapeless/GenericExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -14,7 +19,7 @@ object GenericHelper {
 
   // Simple recursive case class family
   sealed trait Tree[T]
-  case class Leaf[T](t: T) extends Tree[T]
+  case class Leaf[T](t: T)                          extends Tree[T]
   case class Node[T](left: Tree[T], right: Tree[T]) extends Tree[T]
 
   // Polymorphic function which adds 1 to any Int and is the identity
@@ -26,55 +31,57 @@ object GenericHelper {
   case class ExtendedBook(author: String, title: String, id: Int, price: Double, inPrint: Boolean)
 }
 
-
 /** == Generic representation of (sealed families of) case classes ==
-  *
-  * The `Iso`s of earlier shapeless releases have been completely reworked as the new `Generic` type, which closely
-  * resembles the [[https://wiki.haskell.org/GHC.Generics generic programming capabilities introduced to GHC 7.2]].
-  *
-  * `Generic[T]`, where `T` is a case class or an abstract type at the root of a case class hierarchy, maps between values
-  * of `T` and a generic sum of products representation (`HList`s and `Coproduct`s),
-  *
-  * @param name generic
-  */
-object GenericExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * The `Iso`s of earlier shapeless releases have been completely reworked as the new `Generic` type, which closely
+ * resembles the [[https://wiki.haskell.org/GHC.Generics generic programming capabilities introduced to GHC 7.2]].
+ *
+ * `Generic[T]`, where `T` is a case class or an abstract type at the root of a case class hierarchy, maps between values
+ * of `T` and a generic sum of products representation (`HList`s and `Coproduct`s),
+ *
+ * @param name generic
+ */
+object GenericExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
   import GenericHelper._
 
   /** {{{
-    * case class Foo(i: Int, s: String, b: Boolean)
-    *
-    * val fooGen = Generic[Foo]
-    *
-    * val foo = Foo(23, "foo", true)
-    * }}}
-    *
-    * We can convert back and forth case class to their HList Generic representation
-    */
+   * case class Foo(i: Int, s: String, b: Boolean)
+   *
+   * val fooGen = Generic[Foo]
+   *
+   * val foo = Foo(23, "foo", true)
+   * }}}
+   *
+   * We can convert back and forth case class to their HList Generic representation
+   */
   def genericE(res0: fooGen.Repr, res1: Int) = {
     val l = fooGen.to(foo)
     l should be(res0)
-    val r = 13 :: l.tail
+    val r      = 13 :: l.tail
     val newFoo = fooGen.from(r)
     newFoo.i should be(res1)
   }
 
   /** Typically values of Generic for a given case class are materialized using an implicit macro,
-    * allowing a wide variety of structural programming problems to be solved with no or minimal boilerplate.
-    * In particular the existing lens, Scrap Your Boilerplate and generic zipper implementations are now available
-    * for any case class family (recursive families included, as illustrated below) without any additional boilerplate being required
-    * {{{
-    * import poly._
-    *
-    * // Simple recursive case class family
-    * sealed trait Tree[T]
-    * case class Leaf[T](t: T) extends Tree[T]
-    * case class Node[T](left: Tree[T], right: Tree[T]) extends Tree[T]
-    *
-    * // Polymorphic function which adds 1 to any Int and is the identity
-    * // on all other values
-    * object inc extends ->((i: Int) => i+1)
-    * }}}
-    */
+   * allowing a wide variety of structural programming problems to be solved with no or minimal boilerplate.
+   * In particular the existing lens, Scrap Your Boilerplate and generic zipper implementations are now available
+   * for any case class family (recursive families included, as illustrated below) without any additional boilerplate being required
+   * {{{
+   * import poly._
+   *
+   * // Simple recursive case class family
+   * sealed trait Tree[T]
+   * case class Leaf[T](t: T) extends Tree[T]
+   * case class Node[T](left: Tree[T], right: Tree[T]) extends Tree[T]
+   *
+   * // Polymorphic function which adds 1 to any Int and is the identity
+   * // on all other values
+   * object inc extends ->((i: Int) => i+1)
+   * }}}
+   */
   def structural(res0: Int, res1: Int, res2: Int) = {
 
     val tree: Tree[Int] =
@@ -99,21 +106,21 @@ object GenericExercises extends FlatSpec with Matchers with org.scalaexercises.d
   }
 
   /** A natural extension of Generic's mapping of the content of data types onto a sum of products representation
-    * is to a mapping of the data type including its constructor and field names onto a labelled sum of products representation,
-    * ie. a representation in terms of the discriminated unions and records that we saw above.
-    * This is provided by LabelledGeneric. Currently it provides the underpinnings for the use of shapeless lenses with
-    * symbolic path selectors (see next section) and it is expected that it will support many scenarios which would otherwise
-    * require the support of hard to maintain special case macros.
-    * {{{
-    * case class Book(author: String, title: String, id: Int, price: Double)
-    * }}}
-    */
+   * is to a mapping of the data type including its constructor and field names onto a labelled sum of products representation,
+   * ie. a representation in terms of the discriminated unions and records that we saw above.
+   * This is provided by LabelledGeneric. Currently it provides the underpinnings for the use of shapeless lenses with
+   * symbolic path selectors (see next section) and it is expected that it will support many scenarios which would otherwise
+   * require the support of hard to maintain special case macros.
+   * {{{
+   * case class Book(author: String, title: String, id: Int, price: Double)
+   * }}}
+   */
   def labelled(res0: Double, res1: Double, res2: Boolean) = {
     import record._
 
     val bookGen = LabelledGeneric[Book]
-    val tapl = Book("Benjamin Pierce", "Types and Programming Languages", 262162091, 44.11)
-    val rec = bookGen.to(tapl)
+    val tapl    = Book("Benjamin Pierce", "Types and Programming Languages", 262162091, 44.11)
+    val rec     = bookGen.to(tapl)
 
     rec('price) should be(res0)
 
@@ -122,10 +129,9 @@ object GenericExercises extends FlatSpec with Matchers with org.scalaexercises.d
     updatedBook.price should be(res1)
 
     /** {{{
-      * case class ExtendedBook(author: String, title: String, id: Int, price: Double, inPrint: Boolean)
-      * }}}
-      */
-
+     * case class ExtendedBook(author: String, title: String, id: Int, price: Double, inPrint: Boolean)
+     * }}}
+     */
     import syntax.singleton._
 
     val bookExtGen = LabelledGeneric[ExtendedBook]

--- a/src/main/scala/shapeless/HListExercises.scala
+++ b/src/main/scala/shapeless/HListExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -5,7 +10,7 @@ import shapeless._
 import ops.hlist._
 
 object size extends Poly1 {
-  implicit def caseInt = at[Int](x ⇒ 1)
+  implicit def caseInt    = at[Int](x ⇒ 1)
   implicit def caseString = at[String](_.length)
   implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
     at[(T, U)](t ⇒ size(t._1) + size(t._2))
@@ -13,35 +18,37 @@ object size extends Poly1 {
 
 object addSize extends Poly2 {
   implicit def default[T](implicit st: shapelessex.size.Case.Aux[T, Int]) =
-    at[Int, T] { (acc, t) ⇒ acc + size(t) }
+    at[Int, T] { (acc, t) ⇒
+      acc + size(t)
+    }
 }
 
 object CovariantHelper {
 
   trait Fruit
   case class Apple() extends Fruit
-  case class Pear() extends Fruit
+  case class Pear()  extends Fruit
 
   type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
   type APAP = Apple :: Pear :: Apple :: Pear :: HNil
 
   val a: Apple = Apple()
-  val p: Pear = Pear()
+  val p: Pear  = Pear()
 
   val apap: APAP = a :: p :: a :: p :: HNil
 }
 
 /** == Heterogenous lists ==
-  *
-  * shapeless provides a comprehensive Scala `HList` which has many features not shared by other HList implementations.
-  *
-  * @param name heterogenous_lists
-  */
+ *
+ * shapeless provides a comprehensive Scala `HList` which has many features not shared by other HList implementations.
+ *
+ * @param name heterogenous_lists
+ */
 object HListExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   /** It has a `map` operation, applying a polymorphic function value across its elements. This means that it subsumes both
-    * typical `HList`'s and also `KList`'s (`HList`'s whose elements share a common outer type constructor).
-    */
+   * typical `HList`'s and also `KList`'s (`HList`'s whose elements share a common outer type constructor).
+   */
   def exerciseMap(res0: Option[Int], res1: Option[String]) = {
     import poly._
 
@@ -57,7 +64,7 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
   }
 
   /** It also has a flatMap Operation
-    */
+   */
   def exerciseFlatMap(res0: Int, res1: String, res2: Boolean) = {
     import poly.identity
 
@@ -68,14 +75,14 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
   }
 
   /** It has a set of fully polymorphic fold operations which take a polymorphic binary function value. The fold is sensitive
-    * to the static types of all of the elements of the `HList`. Given the earlier definition of size,
-    * {{{
-    * object addSize extends Poly2 {
-    * implicit  def default[T](implicit st: shapelessex.size.Case.Aux[T, Int]) =
-    * at[Int, T]{ (acc, t) => acc+size(t) }
-    * }
-    * }}}
-    */
+   * to the static types of all of the elements of the `HList`. Given the earlier definition of size,
+   * {{{
+   * object addSize extends Poly2 {
+   * implicit  def default[T](implicit st: shapelessex.size.Case.Aux[T, Int]) =
+   * at[Int, T]{ (acc, t) => acc+size(t) }
+   * }
+   * }}}
+   */
   def exerciseFold(res0: Int) = {
 
     val l = 23 :: "foo" :: (13, "wibble") :: HNil
@@ -85,7 +92,7 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
   }
 
   /** It also has a zipper for traversal and persistent update,
-    */
+   */
   def exerciseZipper(res0: Int, res1: (String, Int), res2: Double, res3: Int, res4: Double) = {
     import syntax.zipper._
 
@@ -99,24 +106,24 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
   import CovariantHelper._
 
   /** It is covariant,
-    * {{{
-    * object CovariantHelper {
-    *
-    * trait Fruit
-    * case class Apple() extends Fruit
-    * case class Pear() extends Fruit
-    *
-    * type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
-    * type APAP = Apple :: Pear :: Apple :: Pear :: HNil
-    *
-    * val a : Apple = Apple()
-    * val p : Pear = Pear()
-    *
-    * val apap : APAP = a :: p :: a :: p :: HNil
-    *
-    * }
-    * }}}
-    */
+   * {{{
+   * object CovariantHelper {
+   *
+   * trait Fruit
+   * case class Apple() extends Fruit
+   * case class Pear() extends Fruit
+   *
+   * type FFFF = Fruit :: Fruit :: Fruit :: Fruit :: HNil
+   * type APAP = Apple :: Pear :: Apple :: Pear :: HNil
+   *
+   * val a : Apple = Apple()
+   * val p : Pear = Pear()
+   *
+   * val apap : APAP = a :: p :: a :: p :: HNil
+   *
+   * }
+   * }}}
+   */
   def exerciseCovariant(res0: Boolean) = {
     import scala.reflect.runtime.universe._
 
@@ -124,30 +131,29 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
   }
 
   /** And it has a unify operation which converts it to an HList of elements of the least upper bound of the original types,
-    */
+   */
   def exerciseUnify(res0: Boolean, res1: Boolean) = {
     apap.isInstanceOf[FFFF] should be(res0)
     apap.unify.isInstanceOf[FFFF] should be(res1)
   }
 
   /** It supports conversion to an ordinary Scala `List` of elements of the least upper bound of the original types,
-    */
-  def exerciseConversionToList(res0: List[Fruit]) = {
+   */
+  def exerciseConversionToList(res0: List[Fruit]) =
     apap.toList should be(res0)
-  }
 
   /** And it has a `Typeable` type class instance (see below), allowing, eg. vanilla `List[Any]`'s or `HList`'s with
-    * elements of type `Any` to be safely cast to precisely typed `HList`'s.
-    * These last three features make this `HList` dramatically more practically useful than `HList`'s are typically thought to be:
-    * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries.
-    * This implementation supports the discarding of precise information where necessary.
-    * (eg. to serialize a precisely typed record after construction), and its later reconstruction.
-    * (eg. a weakly typed deserialized record with a known schema can have it's precise typing reestabilished).
-    */
+   * elements of type `Any` to be safely cast to precisely typed `HList`'s.
+   * These last three features make this `HList` dramatically more practically useful than `HList`'s are typically thought to be:
+   * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries.
+   * This implementation supports the discarding of precise information where necessary.
+   * (eg. to serialize a precisely typed record after construction), and its later reconstruction.
+   * (eg. a weakly typed deserialized record with a known schema can have it's precise typing reestabilished).
+   */
   def exerciseTypeable(res0: Option[APAP]) = {
     import syntax.typeable._
 
-    val ffff: FFFF = apap.unify
+    val ffff: FFFF            = apap.unify
     val precise: Option[APAP] = ffff.cast[APAP]
 
     precise should be(res0)

--- a/src/main/scala/shapeless/HMapExercises.scala
+++ b/src/main/scala/shapeless/HMapExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -5,20 +10,20 @@ import shapeless._
 import ops.hlist._
 
 /** == Heterogenous maps ==
-  *
-  * Shapeless provides a heterogenous map which supports an arbitrary relation between the key type and the corresponding
-  * value type,
-  * {{{
-  * class BiMapIS[K, V]
-  * implicit val intToString = new BiMapIS[Int, String]
-  * implicit val stringToInt = new BiMapIS[String, Int]
-  *
-  * val hm = HMap[BiMapIS](23 -> "foo", "bar" -> 13)
-  * //val hm2 = HMap[BiMapIS](23 -> "foo", 23 -> 13)   // Does not compile
-  * }}}
-  *
-  * @param name HMap
-  */
+ *
+ * Shapeless provides a heterogenous map which supports an arbitrary relation between the key type and the corresponding
+ * value type,
+ * {{{
+ * class BiMapIS[K, V]
+ * implicit val intToString = new BiMapIS[Int, String]
+ * implicit val stringToInt = new BiMapIS[String, Int]
+ *
+ * val hm = HMap[BiMapIS](23 -> "foo", "bar" -> 13)
+ * //val hm2 = HMap[BiMapIS](23 -> "foo", 23 -> 13)   // Does not compile
+ * }}}
+ *
+ * @param name HMap
+ */
 object HMapExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object Helper {
@@ -33,15 +38,15 @@ object HMapExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   import Helper._
 
   /** Key/value relation to be enforced: Strings map to Ints and vice versa
-    */
+   */
   def kvEnforcement(res0: Option[String], res1: Option[Int]) = {
     hm.get(23) should be(res0)
     hm.get("bar") should be(res1)
   }
 
   /** And in much the same way that an ordinary monomorphic Scala map can be viewed as a monomorphic function value,
-    * so too can a heterogenous shapeless map be viewed as a polymorphic function value,
-    */
+   * so too can a heterogenous shapeless map be viewed as a polymorphic function value,
+   */
   def mapAsPolyFValue(res0: String :: Int :: HNil) = {
     import hm._
     val l = 23 :: "bar" :: HNil

--- a/src/main/scala/shapeless/LazyExercises.scala
+++ b/src/main/scala/shapeless/LazyExercises.scala
@@ -1,31 +1,36 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == First class lazy values tie implicit recursive knots ==
-  *
-  * Traversals and transformations of recursive types (eg. cons lists or trees) must themselves be recursive. Consequently
-  * type class instances which perform such operations must be recursive values in turn. This is problematic in Scala
-  * at the both the value and the type levels: at the value level the issue is that recursive type class instances would
-  * have to be constructed lazily, whilst Scala doesn't natively support lazy implicit arguments; at the type level the
-  * issue is that during the type checking of expressions constructing recursive implicit values the implicit
-  * resolution mechanism would revisit types in a way that would trip the divergence checker.
-  *
-  * The `Lazy[T]` type constructor and associated macro in shapeless addresses both of these problems in many cases. It is
-  * similar to Scalaz's `Need[T]` and adds lazy implicit construction and suppression of divergence checking. This
-  * supports constructions such as...
-  *
-  * @param name lazy
-  */
+ *
+ * Traversals and transformations of recursive types (eg. cons lists or trees) must themselves be recursive. Consequently
+ * type class instances which perform such operations must be recursive values in turn. This is problematic in Scala
+ * at the both the value and the type levels: at the value level the issue is that recursive type class instances would
+ * have to be constructed lazily, whilst Scala doesn't natively support lazy implicit arguments; at the type level the
+ * issue is that during the type checking of expressions constructing recursive implicit values the implicit
+ * resolution mechanism would revisit types in a way that would trip the divergence checker.
+ *
+ * The `Lazy[T]` type constructor and associated macro in shapeless addresses both of these problems in many cases. It is
+ * similar to Scalaz's `Need[T]` and adds lazy implicit construction and suppression of divergence checking. This
+ * supports constructions such as...
+ *
+ * @param name lazy
+ */
 object LazyExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object Helper {
 
     sealed trait List[+T]
     case class Cons[T](hd: T, tl: List[T]) extends List[T]
-    sealed trait Nil extends List[Nothing]
-    case object Nil extends Nil
+    sealed trait Nil                       extends List[Nothing]
+    case object Nil                        extends Nil
 
     trait Show[T] {
       def apply(t: T): String
@@ -43,17 +48,20 @@ object LazyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
       }
 
       // Case for Cons[T]: note (mutually) recursive implicit argument referencing Show[List[T]]
-      implicit def showCons[T](implicit st: Lazy[Show[T]], sl: Lazy[Show[List[T]]]): Show[Cons[T]] = new Show[Cons[T]] {
+      implicit def showCons[T](
+          implicit st: Lazy[Show[T]],
+          sl: Lazy[Show[List[T]]]): Show[Cons[T]] = new Show[Cons[T]] {
         def apply(t: Cons[T]) = s"Cons(${show(t.hd)(st.value)}, ${show(t.tl)(sl.value)})"
       }
 
       // Case for List[T]: note (mutually) recursive implicit argument referencing Show[Cons[T]]
-      implicit def showList[T](implicit sc: Lazy[Show[Cons[T]]]): Show[List[T]] = new Show[List[T]] {
-        def apply(t: List[T]) = t match {
-          case n: Nil     ⇒ show(n)
-          case c: Cons[T] ⇒ show(c)(sc.value)
+      implicit def showList[T](implicit sc: Lazy[Show[Cons[T]]]): Show[List[T]] =
+        new Show[List[T]] {
+          def apply(t: List[T]) = t match {
+            case n: Nil     ⇒ show(n)
+            case c: Cons[T] ⇒ show(c)(sc.value)
+          }
         }
-      }
     }
 
     def show[T](t: T)(implicit s: Show[T]) = s(t)
@@ -64,50 +72,49 @@ object LazyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   import Helper._
 
   /** {{{
-    * sealed trait List[+T]
-    * case class Cons[T](hd: T, tl: List[T]) extends List[T]
-    * sealed trait Nil extends List[Nothing]
-    * case object Nil extends Nil
-    *
-    * trait Show[T] {
-    * def apply(t: T): String
-    * }
-    *
-    * object Show {
-    * // Base case for Int
-    * implicit def showInt: Show[Int] = new Show[Int] {
-    * def apply(t: Int) = t.toString
-    * }
-    *
-    * // Base case for Nil
-    * implicit def showNil: Show[Nil] = new Show[Nil] {
-    * def apply(t: Nil) = "Nil"
-    * }
-    *
-    * // Case for Cons[T]: note (mutually) recursive implicit argument referencing Show[List[T]]
-    * implicit def showCons[T](implicit st: Lazy[Show[T]], sl: Lazy[Show[List[T]]]): Show[Cons[T]] = new Show[Cons[T]] {
-    * def apply(t: Cons[T]) = s"Cons(${show(t.hd)(st.value)}, ${show(t.tl)(sl.value)})"
-    * }
-    *
-    * // Case for List[T]: note (mutually) recursive implicit argument referencing Show[Cons[T]]
-    * implicit def showList[T](implicit sc: Lazy[Show[Cons[T]]]): Show[List[T]] = new Show[List[T]] {
-    * def apply(t: List[T]) = t match {
-    * case n: Nil => show(n)
-    * case c: Cons[T] => show(c)(sc.value)
-    * }
-    * }
-    * }
-    *
-    * def show[T](t: T)(implicit s: Show[T]) = s(t)
-    *
-    * val l: List[Int] = Cons(1, Cons(2, Cons(3, Nil)))
-    * }}}
-    */
-  def lazyExercise(res0: String) = {
+   * sealed trait List[+T]
+   * case class Cons[T](hd: T, tl: List[T]) extends List[T]
+   * sealed trait Nil extends List[Nothing]
+   * case object Nil extends Nil
+   *
+   * trait Show[T] {
+   * def apply(t: T): String
+   * }
+   *
+   * object Show {
+   * // Base case for Int
+   * implicit def showInt: Show[Int] = new Show[Int] {
+   * def apply(t: Int) = t.toString
+   * }
+   *
+   * // Base case for Nil
+   * implicit def showNil: Show[Nil] = new Show[Nil] {
+   * def apply(t: Nil) = "Nil"
+   * }
+   *
+   * // Case for Cons[T]: note (mutually) recursive implicit argument referencing Show[List[T]]
+   * implicit def showCons[T](implicit st: Lazy[Show[T]], sl: Lazy[Show[List[T]]]): Show[Cons[T]] = new Show[Cons[T]] {
+   * def apply(t: Cons[T]) = s"Cons(${show(t.hd)(st.value)}, ${show(t.tl)(sl.value)})"
+   * }
+   *
+   * // Case for List[T]: note (mutually) recursive implicit argument referencing Show[Cons[T]]
+   * implicit def showList[T](implicit sc: Lazy[Show[Cons[T]]]): Show[List[T]] = new Show[List[T]] {
+   * def apply(t: List[T]) = t match {
+   * case n: Nil => show(n)
+   * case c: Cons[T] => show(c)(sc.value)
+   * }
+   * }
+   * }
+   *
+   * def show[T](t: T)(implicit s: Show[T]) = s(t)
+   *
+   * val l: List[Int] = Cons(1, Cons(2, Cons(3, Nil)))
+   * }}}
+   */
+  def lazyExercise(res0: String) =
     show(l) should be(res0) // Without the Lazy wrappers above the following would diverge ...
 
-    /** which would otherwise be impossible in Scala.
-      */
-  }
+  /** which would otherwise be impossible in Scala.
+ */
 
 }

--- a/src/main/scala/shapeless/LensesExercises.scala
+++ b/src/main/scala/shapeless/LensesExercises.scala
@@ -1,31 +1,36 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == Boilerplate-free lenses for arbitrary case classes ==
-  *
-  * A combination of `LabelledGeneric` and singleton-typed `Symbol` literals supports boilerplate-free lens creation for
-  * arbitrary case classes
-  *
-  * {{{
-  * // A pair of ordinary case classes ...
-  * case class Address(street : String, city : String, postcode : String)
-  * case class Person(name : String, age : Int, address : Address)
-  *
-  * // Some lenses over Person/Address ...
-  * val nameLens     = lens[Person] >> 'name
-  * val ageLens      = lens[Person] >> 'age
-  * val addressLens  = lens[Person] >> 'address
-  * val streetLens   = lens[Person] >> 'address >> 'street
-  * val cityLens     = lens[Person] >> 'address >> 'city
-  * val postcodeLens = lens[Person] >> 'address >> 'postcode
-  *
-  * val person = Person("Joe Grey", 37, Address("Southover Street", "Brighton", "BN2 9UA"))
-  * }}}
-  *
-  * @param name lenses
-  */
+ *
+ * A combination of `LabelledGeneric` and singleton-typed `Symbol` literals supports boilerplate-free lens creation for
+ * arbitrary case classes
+ *
+ * {{{
+ * // A pair of ordinary case classes ...
+ * case class Address(street : String, city : String, postcode : String)
+ * case class Person(name : String, age : Int, address : Address)
+ *
+ * // Some lenses over Person/Address ...
+ * val nameLens     = lens[Person] >> 'name
+ * val ageLens      = lens[Person] >> 'age
+ * val addressLens  = lens[Person] >> 'address
+ * val streetLens   = lens[Person] >> 'address >> 'street
+ * val cityLens     = lens[Person] >> 'address >> 'city
+ * val postcodeLens = lens[Person] >> 'address >> 'postcode
+ *
+ * val person = Person("Joe Grey", 37, Address("Southover Street", "Brighton", "BN2 9UA"))
+ * }}}
+ *
+ * @param name lenses
+ */
 object LensesExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object Helper {
@@ -34,11 +39,11 @@ object LensesExercises extends FlatSpec with Matchers with org.scalaexercises.de
     case class Person(name: String, age: Int, address: Address)
 
     // Some lenses over Person/Address ...
-    val nameLens = lens[Person] >> 'name
-    val ageLens = lens[Person] >> 'age
-    val addressLens = lens[Person] >> 'address
-    val streetLens = lens[Person] >> 'address >> 'street
-    val cityLens = lens[Person] >> 'address >> 'city
+    val nameLens     = lens[Person] >> 'name
+    val ageLens      = lens[Person] >> 'age
+    val addressLens  = lens[Person] >> 'address
+    val streetLens   = lens[Person] >> 'address >> 'street
+    val cityLens     = lens[Person] >> 'address >> 'city
     val postcodeLens = lens[Person] >> 'address >> 'postcode
 
     val person = Person("Joe Grey", 37, Address("Southover Street", "Brighton", "BN2 9UA"))
@@ -47,33 +52,31 @@ object LensesExercises extends FlatSpec with Matchers with org.scalaexercises.de
   import Helper._
 
   /** Read a field
-    */
-  def get(res0: Int) = {
+   */
+  def get(res0: Int) =
     ageLens.get(person) should be(res0)
-  }
 
   /** Update a field
-    */
+   */
   def set(res0: Int) = {
     val updatedPerson = ageLens.set(person)(38)
     updatedPerson.age should be(res0)
   }
 
   /** Transform a field
-    */
+   */
   def modify(res0: Int) = {
     val updatedPerson = ageLens.modify(person)(_ + 1)
     updatedPerson.age should be(res0)
   }
 
   /** Read a nested field
-    */
-  def readNested(res0: String) = {
+   */
+  def readNested(res0: String) =
     streetLens.get(person) should be(res0)
-  }
 
   /** Update a nested field
-    */
+   */
   def updateNested(res0: String) = {
     val updatedPerson = streetLens.set(person)("Montpelier Road")
     updatedPerson.address.street should be(res0)

--- a/src/main/scala/shapeless/PolyExercises.scala
+++ b/src/main/scala/shapeless/PolyExercises.scala
@@ -1,16 +1,21 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
-import poly.{ ~> }
+import poly.{~>}
 
 /** == Polymorphic function values ==
-  *
-  * Ordinary [[http://www.chuusai.com/2012/04/27/shapeless-polymorphic-function-values-1/ Scala function values are monomorphic]]. shapeless, however, provides an encoding of polymorphic
-  * function values. It supports [[http://en.wikipedia.org/wiki/Natural_transformation natural transformations]], which are familiar from libraries like Scalaz
-  *
-  * @param name polymorphic_function_values
-  */
+ *
+ * Ordinary [[http://www.chuusai.com/2012/04/27/shapeless-polymorphic-function-values-1/ Scala function values are monomorphic]]. shapeless, however, provides an encoding of polymorphic
+ * function values. It supports [[http://en.wikipedia.org/wiki/Natural_transformation natural transformations]], which are familiar from libraries like Scalaz
+ *
+ * @param name polymorphic_function_values
+ */
 object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object choose extends (Set ~> Option) {
@@ -18,12 +23,12 @@ object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /** `choose` is a function from Sets to Options with no type specific cases
-    * {{{
-    * object choose extends (Set ~> Option) {
-    * def apply[T](s : Set[T]) = s.headOption
-    * }
-    * }}}
-    */
+   * {{{
+   * object choose extends (Set ~> Option) {
+   * def apply[T](s : Set[T]) = s.headOption
+   * }
+   * }}}
+   */
   def exerciseChoose(res0: Option[Int], res1: Option[Char]) = {
     import shapeless.poly._
     // choose is a function from Sets to Options with no type specific cases
@@ -33,8 +38,8 @@ object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /** Being polymorphic, they may be passed as arguments to functions or methods and then applied to values of different types
-    * within those functions
-    */
+   * within those functions
+   */
   def exercisePairApply(res0: Option[Int], res1: Option[Char]) = {
     def pairApply(f: Set ~> Option) = (f(Set(1, 2, 3)), f(Set('a', 'b', 'c')))
 
@@ -42,22 +47,21 @@ object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   }
 
   /** They are nevertheless interoperable with ordinary monomorphic function values.
-    * `choose` is convertible to an ordinary monomorphic function value and can be
-    * mapped across an ordinary Scala List
-    */
-  def exerciseMonomorphicChoose(res0: Option[Int], res1: Option[Int]) = {
+   * `choose` is convertible to an ordinary monomorphic function value and can be
+   * mapped across an ordinary Scala List
+   */
+  def exerciseMonomorphicChoose(res0: Option[Int], res1: Option[Int]) =
     (List(Set(1, 3, 5), Set(2, 4, 6)) map choose) should be(List(res0, res1))
-  }
 
   /** However, they are [[http://www.chuusai.com/2012/05/10/shapeless-polymorphic-function-values-2/ more general than natural transformations]] and are able to capture type-specific cases
-    * which, as we'll see below, makes them ideal for generic programming,
-    * `size` is a function from Ints or Strings or pairs to a `size` defined
-    * by type specific cases
-    */
+   * which, as we'll see below, makes them ideal for generic programming,
+   * `size` is a function from Ints or Strings or pairs to a `size` defined
+   * by type specific cases
+   */
   def exerciseSize(res0: Int, res1: Int, res2: Int, res3: Int) = {
 
     object size extends Poly1 {
-      implicit def caseInt = at[Int](x ⇒ 1)
+      implicit def caseInt    = at[Int](x ⇒ 1)
       implicit def caseString = at[String](_.length)
       implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
         at[(T, U)](t ⇒ size(t._1) + size(t._2))

--- a/src/main/scala/shapeless/ShapelessLib.scala
+++ b/src/main/scala/shapeless/ShapelessLib.scala
@@ -1,11 +1,16 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 /** Shapeless is a type class and dependent type based generic programming library for Scala.
-  *
-  * @param name shapeless
-  */
+ *
+ * @param name shapeless
+ */
 object ShapelessLib extends org.scalaexercises.definitions.Library {
-  override def owner = "scala-exercises"
+  override def owner      = "scala-exercises"
   override def repository = "exercises-shapeless"
 
   override def color = Some("#F83A4D")

--- a/src/main/scala/shapeless/SingletonExercises.scala
+++ b/src/main/scala/shapeless/SingletonExercises.scala
@@ -1,24 +1,32 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == Singleton-typed literals ==
-  *
-  * Although Scala's typechecker has always represented singleton types for literal values internally, there has not
-  * previously been syntax available to express them, other than by [modifying the compiler][literaltype]. shapeless adds
-  * support for singleton-typed literals via implicit macros.
-  *
-  * @param name singletons_literals
-  *
-  */
-object SingletonExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * Although Scala's typechecker has always represented singleton types for literal values internally, there has not
+ * previously been syntax available to express them, other than by [modifying the compiler][literaltype]. shapeless adds
+ * support for singleton-typed literals via implicit macros.
+ *
+ * @param name singletons_literals
+ *
+ */
+object SingletonExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** Singleton types bridge the gap between the value level and the type level and hence allow the exploration in Scala
-    * of techniques which would typically only be available in languages with support for full-spectrum dependent types.
-    * The latest iteration of shapeless records makes a start on that.
-    * Another simpler application is the use of Int literals to index into HLists and tuples,
-    */
+   * of techniques which would typically only be available in languages with support for full-spectrum dependent types.
+   * The latest iteration of shapeless records makes a start on that.
+   * Another simpler application is the use of Int literals to index into HLists and tuples,
+   */
   def indexHListAndTuples(res0: String, res1: String) = {
     import syntax.std.tuple._
 
@@ -32,31 +40,29 @@ object SingletonExercises extends FlatSpec with Matchers with org.scalaexercises
   import shapeless._, syntax.singleton._
 
   /** The examples in the shapeless tests and the following illustrate other possibilities,
-    * {{{
-    * import shapeless._, syntax.singleton._
-    * }}}
-    */
-  def narrow1(res0: Witness) = {
+   * {{{
+   * import shapeless._, syntax.singleton._
+   * }}}
+   */
+  def narrow1(res0: Witness) =
     res0.value == 23 should be(true)
-  }
 
   /**
-    */
-  def narrow2(res0: Witness) = {
+   */
+  def narrow2(res0: Witness) =
     res0.value == "foo" should be(true)
-  }
 
   /**
-    */
+   */
   def select(res0: Int, res1: String) = {
     val (wTrue, wFalse) = (Witness(true), Witness(false))
 
-    type True = wTrue.T
+    type True  = wTrue.T
     type False = wFalse.T
 
     trait Select[B] { type Out }
 
-    implicit val selInt = new Select[True] { type Out = Int }
+    implicit val selInt    = new Select[True]  { type Out = Int    }
     implicit val selString = new Select[False] { type Out = String }
 
     def select(b: WitnessWith[Select])(t: b.instance.Out) = t

--- a/src/main/scala/shapeless/SizedExercises.scala
+++ b/src/main/scala/shapeless/SizedExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -18,37 +23,36 @@ object SizedHelper {
   )
 }
 
-
 /** == Collections with statically known sizes ==
-  *
-  * shapeless provides collection types with statically known sizes. These can prevent runtime errors such as those that
-  * would result from attempting to take the head of an empty list, and can also verify more complex relationships.
-  *
-  * {{{
-  * def row(cols : Seq[String]) =
-  * cols.mkString("\\"", "\\", \\"", "\\"")
-  *
-  * def csv[N <: Nat]
-  * (hdrs : Sized[Seq[String], N],
-  * rows : List[Sized[Seq[String], N]]) = row(hdrs) :: rows.map(row(_))
-  *
-  * val hdrs = Sized("Title", "Author")
-  *
-  * val rows = List(
-  * Sized("Types and Programming Languages", "Benjamin Pierce"),
-  * Sized("The Implementation of Functional Programming Languages", "Simon Peyton-Jones")
-  * )
-  * }}}
-  *
-  * @param name sized
-  */
+ *
+ * shapeless provides collection types with statically known sizes. These can prevent runtime errors such as those that
+ * would result from attempting to take the head of an empty list, and can also verify more complex relationships.
+ *
+ * {{{
+ * def row(cols : Seq[String]) =
+ * cols.mkString("\\"", "\\", \\"", "\\"")
+ *
+ * def csv[N <: Nat]
+ * (hdrs : Sized[Seq[String], N],
+ * rows : List[Sized[Seq[String], N]]) = row(hdrs) :: rows.map(row(_))
+ *
+ * val hdrs = Sized("Title", "Author")
+ *
+ * val rows = List(
+ * Sized("Types and Programming Languages", "Benjamin Pierce"),
+ * Sized("The Implementation of Functional Programming Languages", "Simon Peyton-Jones")
+ * )
+ * }}}
+ *
+ * @param name sized
+ */
 object SizedExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
   import SizedHelper._
 
   /** In the example below we define a method `csv` whose signature guarantees at compile time that there are exactly as many
-    * column headers provided as colums
-    * TODO : what would be a good exercise for stuff that can only be proven at compile time???
-    */
+   * column headers provided as colums
+   * TODO : what would be a good exercise for stuff that can only be proven at compile time???
+   */
   def sizedEx(res0: Int) = {
 
     // hdrs and rows statically known to have the same number of columns

--- a/src/main/scala/shapeless/TuplesHListExercises.scala
+++ b/src/main/scala/shapeless/TuplesHListExercises.scala
@@ -1,66 +1,69 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == HList-style operations on standard Scala tuples ==
-  *
-  * shapeless allows standard Scala tuples to be manipulated in exactly the same ways as `HList`s
-  * @param name tuples
-  */
-object TuplesHListExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * shapeless allows standard Scala tuples to be manipulated in exactly the same ways as `HList`s
+ * @param name tuples
+ */
+object TuplesHListExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   import syntax.std.tuple._
 
   /** {{{
-    * import syntax.std.tuple._
-    * }}}
-    * head
-    */
-  def head(res0: Int) = {
+   * import syntax.std.tuple._
+   * }}}
+   * head
+   */
+  def head(res0: Int) =
     (23, "foo", true).head should be(res0)
-  }
 
   /** tail
-    */
-  def tail(res0: (String, Boolean)) = {
+   */
+  def tail(res0: (String, Boolean)) =
     (23, "foo", true).tail should be(res0)
-  }
 
   /** drop
-    */
-  def drop(res0: Tuple1[Boolean]) = {
+   */
+  def drop(res0: Tuple1[Boolean]) =
     (23, "foo", true).drop(2) should be(res0)
-  }
 
   /** take
-    */
-  def take(res0: (Int, String)) = {
+   */
+  def take(res0: (Int, String)) =
     (23, "foo", true).take(2) should be(res0)
-  }
 
   /** split
-    */
-  def split(res0: (Tuple1[Int], (String, Boolean))) = {
+   */
+  def split(res0: (Tuple1[Int], (String, Boolean))) =
     (23, "foo", true).split(1) should be(res0)
-  }
 
   /** prepend
-    */
+   */
   def prepend(res0: (Int, String, Boolean)) = {
     val l = 23 +: ("foo", true)
     l should be(res0)
   }
 
   /** append
-    */
+   */
   def append(res0: (Int, String, Boolean)) = {
     val l = (23, "foo") :+ true
     l should be(res0)
   }
 
   /** concatenate
-    */
+   */
   def concatenate(res0: (Int, String, Boolean, Double)) = {
     val l = (23, "foo") ++ (true, 2.0)
     l should be(res0)
@@ -73,28 +76,28 @@ object TuplesHListExercises extends FlatSpec with Matchers with org.scalaexercis
   }
 
   /** map
-    * {{{
-    * import poly._
-    *
-    * object option extends (Id ~> Option) {
-    * def apply[T](t: T) = Option(t)
-    * }
-    * }}}
-    */
+   * {{{
+   * import poly._
+   *
+   * object option extends (Id ~> Option) {
+   * def apply[T](t: T) = Option(t)
+   * }
+   * }}}
+   */
   def map(res0: (Option[Int], Option[String], Option[Boolean])) = {
     val l = (23, "foo", true) map option
     l should be(res0)
   }
 
   /** flatMap
-    */
+   */
   def flatMap(res0: (Int, String, Boolean, Double)) = {
     val l = ((23, "foo"), (), (true, 2.0)) flatMap identity
     l should be(res0)
   }
 
   object sizeOf extends Poly1 {
-    implicit def caseInt = at[Int](x ⇒ 1)
+    implicit def caseInt    = at[Int](x ⇒ 1)
     implicit def caseString = at[String](_.length)
     implicit def caseTuple[T, U](implicit st: Case.Aux[T, Int], su: Case.Aux[U, Int]) =
       at[(T, U)](t ⇒ sizeOf(t._1) + sizeOf(t._2))
@@ -102,43 +105,42 @@ object TuplesHListExercises extends FlatSpec with Matchers with org.scalaexercis
 
   object addSize extends Poly2 {
     implicit def default[T](implicit st: sizeOf.Case.Aux[T, Int]) =
-      at[Int, T] { (acc, t) ⇒ acc + sizeOf(t) }
+      at[Int, T] { (acc, t) ⇒
+        acc + sizeOf(t)
+      }
   }
 
   /** fold
-    * {{{
-    * object size extends Poly1 {
-    * implicit def caseInt = at[Int](x => 1)
-    * implicit def caseString = at[String](_.length)
-    * implicit def caseTuple[T, U]
-    * (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
-    * at[(T, U)](t => size(t._1)+size(t._2))
-    * }
-    *
-    * object addSize extends Poly2 {
-    * implicit def default[T](implicit st: size.Case.Aux[T, Int]) =
-    * at[Int, T]{ (acc, t) => acc+size(t) }
-    * }
-    * }}}
-    */
-  def fold(res0: Int) = {
+   * {{{
+   * object size extends Poly1 {
+   * implicit def caseInt = at[Int](x => 1)
+   * implicit def caseString = at[String](_.length)
+   * implicit def caseTuple[T, U]
+   * (implicit st : Case.Aux[T, Int], su : Case.Aux[U, Int]) =
+   * at[(T, U)](t => size(t._1)+size(t._2))
+   * }
+   *
+   * object addSize extends Poly2 {
+   * implicit def default[T](implicit st: size.Case.Aux[T, Int]) =
+   * at[Int, T]{ (acc, t) => acc+size(t) }
+   * }
+   * }}}
+   */
+  def fold(res0: Int) =
     (23, "foo", (13, "wibble")).foldLeft(0)(addSize) should be(res0)
-  }
 
   /** conversion to `HList`
-    */
-  def toHList(res0: Int :: String :: Boolean :: HNil) = {
+   */
+  def toHList(res0: Int :: String :: Boolean :: HNil) =
     (23, "foo", true).productElements should be(res0)
-  }
 
   /** conversion to `List`
-    */
-  def toList(res0: List[Any]) = {
+   */
+  def toList(res0: List[Any]) =
     (23, "foo", true).toList should be(res0)
-  }
 
   /** zipper
-    */
+   */
   def zipper(res0: (Int, (String, Boolean), Double)) = {
     import syntax.zipper._
     val l = (23, ("foo", true), 2.0).toZipper.right.down.put("bar").root.reify

--- a/src/main/scala/shapeless/TypeCheckingExercises.scala
+++ b/src/main/scala/shapeless/TypeCheckingExercises.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
@@ -6,29 +11,32 @@ import shapeless._
 import scala.util.Try
 
 /** == Testing for non-compilation ==
-  *
-  * Libraries like shapeless which make extensive use of type-level computation and implicit resolution often need to
-  * provide guarantees that certain expressions *don't* typecheck. Testing these guarantees is supported in shapeless via
-  * the `illTyped` macro,
-  * {{{
-  * import shapeless.test.illTyped
-  *
-  * scala> illTyped { """1+1 : Boolean""" }
-  *
-  * scala> illTyped { """1+1 : Int""" }
-  * <console>:19: error: Type-checking succeeded unexpectedly.
-  * Expected some error.
-  * illTyped { """1+1 : Int""" }
-  * }}}
-  *
-  * @param name type_checking
-  */
-object TypeCheckingExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * Libraries like shapeless which make extensive use of type-level computation and implicit resolution often need to
+ * provide guarantees that certain expressions *don't* typecheck. Testing these guarantees is supported in shapeless via
+ * the `illTyped` macro,
+ * {{{
+ * import shapeless.test.illTyped
+ *
+ * scala> illTyped { """1+1 : Boolean""" }
+ *
+ * scala> illTyped { """1+1 : Int""" }
+ * <console>:19: error: Type-checking succeeded unexpectedly.
+ * Expected some error.
+ * illTyped { """1+1 : Int""" }
+ * }}}
+ *
+ * @param name type_checking
+ */
+object TypeCheckingExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** The testing library ScalaTest also has a way of checking that a snippet of code
-    * does not compile: pass it in to `assertTypeError`. What will happen if we combine
-    * `illTyped` and `assertTypeError`? (Hint: it's like applying a double negative.)
-    */
+   * does not compile: pass it in to `assertTypeError`. What will happen if we combine
+   * `illTyped` and `assertTypeError`? (Hint: it's like applying a double negative.)
+   */
   def typeCheckingTest(res0: Boolean, res1: Boolean) = {
 
     import shapeless.test.illTyped

--- a/src/main/scala/shapeless/TypeSafeCastExercises.scala
+++ b/src/main/scala/shapeless/TypeSafeCastExercises.scala
@@ -1,22 +1,33 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapelessex
 
 import org.scalatest._
 import shapeless._
 
 /** == Type safe cast ==
-  *
-  * shapeless provides a `Typeable` type class which provides a type safe cast operation. `cast` returns an `Option` of the
-  * target type rather than throwing an exception if the value is of the incorrect type, as can happen with separate
-  * `isInstanceOf` and `asInstanceOf` operations. `Typeable` handles primitive values correctly and will recover erased
-  * types in many circumstances
-  *
-  * @param name type_safe_cast
-  */
-object TypeSafeCastExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+ *
+ * shapeless provides a `Typeable` type class which provides a type safe cast operation. `cast` returns an `Option` of the
+ * target type rather than throwing an exception if the value is of the incorrect type, as can happen with separate
+ * `isInstanceOf` and `asInstanceOf` operations. `Typeable` handles primitive values correctly and will recover erased
+ * types in many circumstances
+ *
+ * @param name type_safe_cast
+ */
+object TypeSafeCastExercises
+    extends FlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /**
-    */
-  def typesafeCast(res0: Option[List[Vector[String]]], res1: Option[List[Vector[Int]]], res2: Option[List[List[String]]]) = {
+   */
+  def typesafeCast(
+      res0: Option[List[Vector[String]]],
+      res1: Option[List[Vector[Int]]],
+      res2: Option[List[List[String]]]) = {
     import syntax.typeable._
 
     val l: Any = List(Vector("foo", "bar", "baz"), Vector("wibble"))
@@ -26,28 +37,28 @@ object TypeSafeCastExercises extends FlatSpec with Matchers with org.scalaexerci
   }
 
   /** An extractor based on `Typeable` is also available, allowing more precision in pattern matches,
-    */
+   */
   def extractor(res0: Int) = {
 
     val `List[String]` = TypeCase[List[String]]
-    val `List[Int]` = TypeCase[List[Int]]
-    val l = List(1, 2, 3)
+    val `List[Int]`    = TypeCase[List[Int]]
+    val l              = List(1, 2, 3)
 
     val result = (l: Any) match {
-      case `List[String]`(List(s, _*)) ⇒ s.length
-      case `List[Int]`(List(i, _*))    ⇒ i + 1
+      case `List[String]`(List(s, _ *)) ⇒ s.length
+      case `List[Int]`(List(i, _ *))    ⇒ i + 1
     }
 
     result should be(res0)
 
     /** The equivalent pattern match without `Typeable`/`TypeCase` would result in a compile-time warning about the erasure
-      * of the list's type parameter, then at runtime spuriously match the `List[String]` case and fail with a
-      * `ClassCastException` while attempting to evaluate its right hand side.
-      *
-      * Be aware that the increased precision and safety provided by `Typeable`/`TypeCase` don't alter the fact that type
-      * caseing should be avoided in general other than at boundaries with external components which are intrinsically untyped
-      * (eg. serialization points) or which otherwise have poor type discipline.
-      */
+   * of the list's type parameter, then at runtime spuriously match the `List[String]` case and fail with a
+   * `ClassCastException` while attempting to evaluate its right hand side.
+   *
+   * Be aware that the increased precision and safety provided by `Typeable`/`TypeCase` don't alter the fact that type
+   * caseing should be avoided in general other than at boundaries with external components which are intrinsically untyped
+   * (eg. serialization points) or which otherwise have poor type discipline.
+   */
   }
 
 }

--- a/src/test/scala/shapeless/AritySpec.scala
+++ b/src/test/scala/shapeless/AritySpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/AutoTypeClassSpec.scala
+++ b/src/test/scala/shapeless/AutoTypeClassSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/CoproductSpec.scala
+++ b/src/test/scala/shapeless/CoproductSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/ExtensibleRecordsSpec.scala
+++ b/src/test/scala/shapeless/ExtensibleRecordsSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._
@@ -29,7 +34,9 @@ class ExtensibleRecordsSpec extends Spec with Checkers {
     check(
       Test.testSuccess(
         ExtensibleRecordsExercises.updated _,
-        46.11 :: true :: { "Benjamin Pierce" :: "Types and Programming Languages" :: 46.11 :: true :: HNil } :: HNil
+        46.11 :: true :: {
+          "Benjamin Pierce" :: "Types and Programming Languages" :: 46.11 :: true :: HNil
+        } :: HNil
       )
     )
   }

--- a/src/test/scala/shapeless/GenericExercisesSpec.scala
+++ b/src/test/scala/shapeless/GenericExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/HListSpec.scala
+++ b/src/test/scala/shapeless/HListSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/HMapExercisesSpec.scala
+++ b/src/test/scala/shapeless/HMapExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/LazyExercisesSpec.scala
+++ b/src/test/scala/shapeless/LazyExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/LensesExercisesSpec.scala
+++ b/src/test/scala/shapeless/LensesExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/PolySpec.scala
+++ b/src/test/scala/shapeless/PolySpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/SingletonExercisesSpec.scala
+++ b/src/test/scala/shapeless/SingletonExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._
@@ -26,7 +31,7 @@ class SingletonExercisesSpec extends Spec with Checkers {
     )
   }
 
-  // TODO disabled until divergent implicit expansion is fixed for singleton types on scalacheck-shapeless int lib 
+  // TODO disabled until divergent implicit expansion is fixed for singleton types on scalacheck-shapeless int lib
   //   https://gitter.im/milessabin/shapeless?at=56fcf50fbbffcc665faad6e5
   /*  def `narrow 1` = {
     check(

--- a/src/test/scala/shapeless/SizedExercisesSpec.scala
+++ b/src/test/scala/shapeless/SizedExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/src/test/scala/shapeless/TuplesHListExercisesSpec.scala
+++ b/src/test/scala/shapeless/TuplesHListExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._
@@ -118,4 +123,3 @@ class TuplesHListExercisesSpec extends Spec with Checkers {
   }
 
 }
-

--- a/src/test/scala/shapeless/TypeCheckingExercisesSpec.scala
+++ b/src/test/scala/shapeless/TypeCheckingExercisesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * scala-exercises - exercises-shapeless
+ * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ */
+
 package shapeless
 
 import org.scalacheck.Shapeless._

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
This integration has no effect on the deployed application since we are releasing a snapshot new version.

There are multiples changes across the source code, most of them due to scalafmt autoformatting or file headers. The important changes here are:

* build.sbt
* project/plugins.sbt
* project/build.properties
* project/ProjectPlugin.scala
* README.md
* travis.yml
* version.sbt

Please, @raulraja could you review? Thanks!