### PR TITLE
Use openjdk8 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
 - 2.11.11
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - sbt test
 


### PR DESCRIPTION
* Use openjdk8 for Travis builds as oraclejkd8 is no longer supported in the default Linux image