### PR TITLE
Update to Scala 2.12.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
-val scalaExercisesV = "0.4.0-SNAPSHOT"
+import ProjectPlugin.autoImport._
+
+val scalaExercisesV = "0.5.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 
@@ -9,10 +11,10 @@ lazy val shapeless = (project in file("."))
     libraryDependencies ++= Seq(
       dep("exercise-compiler"),
       dep("definitions"),
-      %%("shapeless"),
-      %%("scalatest"),
-      %%("scalacheck"),
-      %%("scheckShapeless")
+      %%("shapeless", V.shapeless),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,16 +1,29 @@
-import de.heikoseeberger.sbtheader.HeaderPattern
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader.License._
 import sbt.Keys._
 import sbt._
+import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies._
 import sbtorgpolicies.model._
-import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val V = new {
+      val scala212: String            = "2.12.10"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
+    }
+  }
+
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -25,23 +38,17 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := "2.11.11",
+      scalaVersion := V.scala212,
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := Seq("2.11.11"),
       resolvers ++= Seq(
         Resolver.mavenLocal,
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases")
       ),
-      scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
-      headers := Map(
-        "scala" -> (HeaderPattern.cStyleBlockComment,
-          s"""|/*
-              | * scala-exercises - ${name.value}
-              | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
-              | */
-              |
-            |""".stripMargin)
-      )
+      scalacOptions := sbtorgpolicies.model.scalacLanguageOptions,
+      headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+                                       |
+                                       |""".stripMargin))
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,5 +2,5 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots")
 )
 
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.13")
+addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/shapeless/ArityExercises.scala
+++ b/src/main/scala/shapeless/ArityExercises.scala
@@ -1,13 +1,13 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
 import org.scalatest._
 import shapeless._
-import ops.hlist._
 import ops.function._
 import syntax.std.function._
 
@@ -39,8 +39,8 @@ object ArityExercises extends FlatSpec with Matchers with org.scalaexercises.def
   /** Abstracting over arity
    */
   def arityTest(res0: Int, res1: Int) = {
-    applyProduct(1, 2)((_: Int) + (_: Int)) should be(res0)
-    applyProduct(1, 2, 3)((_: Int) * (_: Int) * (_: Int)) should be(res1)
+    applyProduct((1, 2))((_: Int) + (_: Int)) should be(res0)
+    applyProduct((1, 2, 3))((_: Int) * (_: Int) * (_: Int)) should be(res1)
   }
 
 }

--- a/src/main/scala/shapeless/AutoTypeClassExercises.scala
+++ b/src/main/scala/shapeless/AutoTypeClassExercises.scala
@@ -1,10 +1,12 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
+import scala.language.implicitConversions
 import org.scalatest._
 import shapeless._
 
@@ -167,7 +169,6 @@ object AutoTypeClassExercises
   def monoidDerivation(res0: Int, res1: String, res2: Boolean, res3: String, res4: Double) = {
 
     import MonoidSyntax._
-    import Monoid.typeClass._
 
     val fooCombined = Foo(13, "foo") |+| Foo(23, "bar")
     fooCombined should be(Foo(res0, res1))

--- a/src/main/scala/shapeless/CoproductExercises.scala
+++ b/src/main/scala/shapeless/CoproductExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -66,7 +67,7 @@ object CoproductExercises
    * adding labels to the elements of a Coproduct gives us a discriminated union.
    */
   def unionE(res0: Option[Int], res1: Option[String], res2: Option[Boolean]) = {
-    import record._, union._, syntax.singleton._
+    import union._, syntax.singleton._
 
     type U = Union.`'i -> Int, 's -> String, 'b -> Boolean`.T
 

--- a/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
+++ b/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
@@ -1,13 +1,12 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
 import org.scalatest._
-import shapeless._
-import ops.hlist._
 
 /** == Extensible records ==
  *

--- a/src/main/scala/shapeless/GenericExercises.scala
+++ b/src/main/scala/shapeless/GenericExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -41,10 +42,7 @@ object GenericHelper {
  *
  * @param name generic
  */
-object GenericExercises
-    extends FlatSpec
-    with Matchers
-    with org.scalaexercises.definitions.Section {
+object GenericExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
   import GenericHelper._
 
   /** {{{

--- a/src/main/scala/shapeless/HListExercises.scala
+++ b/src/main/scala/shapeless/HListExercises.scala
@@ -1,13 +1,13 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
 import org.scalatest._
 import shapeless._
-import ops.hlist._
 
 object size extends Poly1 {
   implicit def caseInt    = at[Int](x ⇒ 1)
@@ -143,13 +143,13 @@ object HListExercises extends FlatSpec with Matchers with org.scalaexercises.def
     apap.toList should be(res0)
 
   /** And it has a `Typeable` type class instance (see below), allowing, eg. vanilla `List[Any]`'s or `HList`'s with
-    * elements of type `Any` to be safely cast to precisely typed `HList`'s.
-    * These last three features make this `HList` dramatically more practically useful than `HList`'s are typically thought to be:
-    * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries.
-    * This implementation supports the discarding of precise information where necessary.
-    * (eg. to serialize a precisely typed record after construction), and its later reconstruction.
-    * (eg. a weakly typed deserialized record with a known schema can have its precise typing reestablished).
-    */
+   * elements of type `Any` to be safely cast to precisely typed `HList`'s.
+   * These last three features make this `HList` dramatically more practically useful than `HList`'s are typically thought to be:
+   * normally the full type information required to work with them is too fragile to cross subtyping or I/O boundaries.
+   * This implementation supports the discarding of precise information where necessary.
+   * (eg. to serialize a precisely typed record after construction), and its later reconstruction.
+   * (eg. a weakly typed deserialized record with a known schema can have its precise typing reestablished).
+   */
   def exerciseTypeable(res0: Option[APAP]) = {
     import syntax.typeable._
 

--- a/src/main/scala/shapeless/HMapExercises.scala
+++ b/src/main/scala/shapeless/HMapExercises.scala
@@ -1,13 +1,13 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
 import org.scalatest._
 import shapeless._
-import ops.hlist._
 
 /** == Heterogenous maps ==
  *

--- a/src/main/scala/shapeless/LazyExercises.scala
+++ b/src/main/scala/shapeless/LazyExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -48,11 +49,10 @@ object LazyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
       }
 
       // Case for Cons[T]: note (mutually) recursive implicit argument referencing Show[List[T]]
-      implicit def showCons[T](
-          implicit st: Lazy[Show[T]],
-          sl: Lazy[Show[List[T]]]): Show[Cons[T]] = new Show[Cons[T]] {
-        def apply(t: Cons[T]) = s"Cons(${show(t.hd)(st.value)}, ${show(t.tl)(sl.value)})"
-      }
+      implicit def showCons[T](implicit st: Lazy[Show[T]], sl: Lazy[Show[List[T]]]): Show[Cons[T]] =
+        new Show[Cons[T]] {
+          def apply(t: Cons[T]) = s"Cons(${show(t.hd)(st.value)}, ${show(t.tl)(sl.value)})"
+        }
 
       // Case for List[T]: note (mutually) recursive implicit argument referencing Show[Cons[T]]
       implicit def showList[T](implicit sc: Lazy[Show[Cons[T]]]): Show[List[T]] =

--- a/src/main/scala/shapeless/LensesExercises.scala
+++ b/src/main/scala/shapeless/LensesExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex

--- a/src/main/scala/shapeless/PolyExercises.scala
+++ b/src/main/scala/shapeless/PolyExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -30,7 +31,6 @@ object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
    * }}}
    */
   def exerciseChoose(res0: Option[Int], res1: Option[Char]) = {
-    import shapeless.poly._
     // choose is a function from Seqs to Options with no type specific cases
 
     choose(Seq(1, 2, 3)) should be(res0)
@@ -43,7 +43,7 @@ object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.defi
   def exercisePairApply(res0: Option[Int], res1: Option[Char]) = {
     def pairApply(f: Seq ~> Option) = (f(Seq(1, 2, 3)), f(Seq('a', 'b', 'c')))
 
-    pairApply(choose) should be(res0, res1)
+    pairApply(choose) should be((res0, res1))
   }
 
   /** They are nevertheless interoperable with ordinary monomorphic function values.

--- a/src/main/scala/shapeless/ShapelessLib.scala
+++ b/src/main/scala/shapeless/ShapelessLib.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex

--- a/src/main/scala/shapeless/SingletonExercises.scala
+++ b/src/main/scala/shapeless/SingletonExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -37,7 +38,7 @@ object SingletonExercises
     tuple(1) should be(res1)
   }
 
-  import shapeless._, syntax.singleton._
+  import shapeless._
 
   /** The examples in the shapeless tests and the following illustrate other possibilities,
    * {{{

--- a/src/main/scala/shapeless/SizedExercises.scala
+++ b/src/main/scala/shapeless/SizedExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex

--- a/src/main/scala/shapeless/TuplesHListExercises.scala
+++ b/src/main/scala/shapeless/TuplesHListExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex

--- a/src/main/scala/shapeless/TypeCheckingExercises.scala
+++ b/src/main/scala/shapeless/TypeCheckingExercises.scala
@@ -1,12 +1,12 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
 
 import org.scalatest._
-import shapeless._
 
 import scala.util.Try
 

--- a/src/main/scala/shapeless/TypeSafeCastExercises.scala
+++ b/src/main/scala/shapeless/TypeSafeCastExercises.scala
@@ -1,6 +1,7 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapelessex
@@ -45,8 +46,8 @@ object TypeSafeCastExercises
     val l              = List(1, 2, 3)
 
     val result = (l: Any) match {
-      case `List[String]`(List(s, _ *)) ⇒ s.length
-      case `List[Int]`(List(i, _ *))    ⇒ i + 1
+      case `List[String]`(List(s, _*)) ⇒ s.length
+      case `List[Int]`(List(i, _*))    ⇒ i + 1
     }
 
     result should be(res0)

--- a/src/test/scala/shapeless/AritySpec.scala
+++ b/src/test/scala/shapeless/AritySpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class AritySpec extends Spec with Checkers {
+class AritySpec extends RefSpec with Checkers {
   def `abstracting over arity` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/AutoTypeClassSpec.scala
+++ b/src/test/scala/shapeless/AutoTypeClassSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class AutoTypeClassSpec extends Spec with Checkers {
+class AutoTypeClassSpec extends RefSpec with Checkers {
   def `monoid derivation` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/CoproductSpec.scala
+++ b/src/test/scala/shapeless/CoproductSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class CoproductSpec extends Spec with Checkers {
+class CoproductSpec extends RefSpec with Checkers {
   def `selection op` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/ExtensibleRecordsSpec.scala
+++ b/src/test/scala/shapeless/ExtensibleRecordsSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class ExtensibleRecordsSpec extends Spec with Checkers {
+class ExtensibleRecordsSpec extends RefSpec with Checkers {
   def `result types` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/GenericExercisesSpec.scala
+++ b/src/test/scala/shapeless/GenericExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class GenericExercisesSpec extends Spec with Checkers {
+class GenericExercisesSpec extends RefSpec with Checkers {
   def `Generic from to` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/HListSpec.scala
+++ b/src/test/scala/shapeless/HListSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class HListSpec extends Spec with Checkers {
+class HListSpec extends RefSpec with Checkers {
   def `map op` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/HMapExercisesSpec.scala
+++ b/src/test/scala/shapeless/HMapExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class HMapExercisesSpec extends Spec with Checkers {
+class HMapExercisesSpec extends RefSpec with Checkers {
   def `k/v enforcement` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/LazyExercisesSpec.scala
+++ b/src/test/scala/shapeless/LazyExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class LazyExercisesSpec extends Spec with Checkers {
+class LazyExercisesSpec extends RefSpec with Checkers {
 
   def `lazy helps avoiding divergence` = {
     check(

--- a/src/test/scala/shapeless/LensesExercisesSpec.scala
+++ b/src/test/scala/shapeless/LensesExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class LensesExercisesSpec extends Spec with Checkers {
+class LensesExercisesSpec extends RefSpec with Checkers {
 
   def `get a field` = {
     check(

--- a/src/test/scala/shapeless/PolySpec.scala
+++ b/src/test/scala/shapeless/PolySpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class PolySpec extends Spec with Checkers {
+class PolySpec extends RefSpec with Checkers {
   def `poly choose` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/SingletonExercisesSpec.scala
+++ b/src/test/scala/shapeless/SingletonExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class SingletonExercisesSpec extends Spec with Checkers {
+class SingletonExercisesSpec extends RefSpec with Checkers {
 
   def `index into HList and Tuples` = {
     check(

--- a/src/test/scala/shapeless/SizedExercisesSpec.scala
+++ b/src/test/scala/shapeless/SizedExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class SizedExercisesSpec extends Spec with Checkers {
+class SizedExercisesSpec extends RefSpec with Checkers {
   def `Sized usage` = {
     check(
       Test.testSuccess(

--- a/src/test/scala/shapeless/TuplesHListExercisesSpec.scala
+++ b/src/test/scala/shapeless/TuplesHListExercisesSpec.scala
@@ -1,18 +1,19 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.syntax.std.tuple._
 import shapelessex._
 
-class TuplesHListExercisesSpec extends Spec with Checkers {
+class TuplesHListExercisesSpec extends RefSpec with Checkers {
 
   def `head op` = {
     check(

--- a/src/test/scala/shapeless/TypeCheckingExercisesSpec.scala
+++ b/src/test/scala/shapeless/TypeCheckingExercisesSpec.scala
@@ -1,17 +1,18 @@
 /*
- * scala-exercises - exercises-shapeless
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-shapeless
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
 package shapeless
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
-import org.scalatest.Spec
-import org.scalatest.prop.Checkers
+import org.scalatest.refspec.RefSpec
+import org.scalatestplus.scalacheck.Checkers
 import shapelessex._
 
-class TypeCheckingExercisesSpec extends Spec with Checkers {
+class TypeCheckingExercisesSpec extends RefSpec with Checkers {
   def `testing for non-compilation` = {
     check(
       Test.testSuccess(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates Scala version to 2.12.10 and updates dependency version. Removed deprecation warnings and added compatibility with Scala Exercises 0.5.0-SNAPSHOT