### PR TITLE
Updated ScalaTest 3.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ lazy val shapeless = (project in file("."))
       %%("shapeless", V.shapeless),
       %%("scalatest", V.scalatest),
       %%("scalacheck", V.scalacheck),
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless,
+      "org.scalatestplus"          %% "scalatestplus-scalacheck"    % V.scalatestplusScheck
     )
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -17,7 +17,8 @@ object ProjectPlugin extends AutoPlugin {
     lazy val V = new {
       val scala212: String            = "2.12.10"
       val shapeless: String           = "2.3.3"
-      val scalatest: String           = "3.0.8"
+      val scalatest: String           = "3.1.0"
+      val scalatestplusScheck: String = "3.1.0.0-RC2"
       val scalacheck: String          = "1.14.2"
       val scalacheckShapeless: String = "1.2.3"
     }

--- a/src/main/scala/shapeless/ArityExercises.scala
+++ b/src/main/scala/shapeless/ArityExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 import ops.function._
 import syntax.std.function._
@@ -33,7 +34,10 @@ object Helper {
  *
  * @param name arity
  */
-object ArityExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object ArityExercises
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
   import Helper._
 
   /** Abstracting over arity

--- a/src/main/scala/shapeless/AutoTypeClassExercises.scala
+++ b/src/main/scala/shapeless/AutoTypeClassExercises.scala
@@ -7,7 +7,8 @@
 package shapelessex
 
 import scala.language.implicitConversions
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 trait Monoid[T] {
@@ -145,7 +146,7 @@ object MonoidSyntax {
  *
  */
 object AutoTypeClassExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/CoproductExercises.scala
+++ b/src/main/scala/shapeless/CoproductExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == Coproducts and discriminated unions ==
@@ -18,7 +19,7 @@ import shapeless._
  * @param name coproducts
  */
 object CoproductExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
+++ b/src/main/scala/shapeless/ExtensibleRecordsExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** == Extensible records ==
  *
@@ -29,7 +30,7 @@ import org.scalatest._
  *
  */
 object ExtensibleRecordsExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/GenericExercises.scala
+++ b/src/main/scala/shapeless/GenericExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 object GenericHelper {
@@ -42,7 +43,10 @@ object GenericHelper {
  *
  * @param name generic
  */
-object GenericExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object GenericExercises
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
   import GenericHelper._
 
   /** {{{

--- a/src/main/scala/shapeless/HListExercises.scala
+++ b/src/main/scala/shapeless/HListExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 object size extends Poly1 {
@@ -44,7 +45,10 @@ object CovariantHelper {
  *
  * @param name heterogenous_lists
  */
-object HListExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object HListExercises
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   /** It has a `map` operation, applying a polymorphic function value across its elements. This means that it subsumes both
    * typical `HList`'s and also `KList`'s (`HList`'s whose elements share a common outer type constructor).

--- a/src/main/scala/shapeless/HMapExercises.scala
+++ b/src/main/scala/shapeless/HMapExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == Heterogenous maps ==
@@ -24,7 +25,7 @@ import shapeless._
  *
  * @param name HMap
  */
-object HMapExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object HMapExercises extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object Helper {
     class BiMapIS[K, V]

--- a/src/main/scala/shapeless/LazyExercises.scala
+++ b/src/main/scala/shapeless/LazyExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == First class lazy values tie implicit recursive knots ==
@@ -24,7 +25,7 @@ import shapeless._
  *
  * @param name lazy
  */
-object LazyExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object LazyExercises extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object Helper {
 

--- a/src/main/scala/shapeless/LensesExercises.scala
+++ b/src/main/scala/shapeless/LensesExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == Boilerplate-free lenses for arbitrary case classes ==
@@ -32,7 +33,10 @@ import shapeless._
  *
  * @param name lenses
  */
-object LensesExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object LensesExercises
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
 
   object Helper {
     // A pair of ordinary case classes ...

--- a/src/main/scala/shapeless/PolyExercises.scala
+++ b/src/main/scala/shapeless/PolyExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 import poly.{~>}
 
@@ -17,7 +18,7 @@ import poly.{~>}
  *
  * @param name polymorphic_function_values
  */
-object PolyExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object PolyExercises extends AnyFlatSpec with Matchers with org.scalaexercises.definitions.Section {
 
   object choose extends (Seq ~> Option) {
     def apply[T](s: Seq[T]) = s.headOption

--- a/src/main/scala/shapeless/SingletonExercises.scala
+++ b/src/main/scala/shapeless/SingletonExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == Singleton-typed literals ==
@@ -19,7 +20,7 @@ import shapeless._
  *
  */
 object SingletonExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/SizedExercises.scala
+++ b/src/main/scala/shapeless/SizedExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 object SizedHelper {
@@ -47,7 +48,10 @@ object SizedHelper {
  *
  * @param name sized
  */
-object SizedExercises extends FlatSpec with Matchers with org.scalaexercises.definitions.Section {
+object SizedExercises
+    extends AnyFlatSpec
+    with Matchers
+    with org.scalaexercises.definitions.Section {
   import SizedHelper._
 
   /** In the example below we define a method `csv` whose signature guarantees at compile time that there are exactly as many

--- a/src/main/scala/shapeless/TuplesHListExercises.scala
+++ b/src/main/scala/shapeless/TuplesHListExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == HList-style operations on standard Scala tuples ==
@@ -15,7 +16,7 @@ import shapeless._
  * @param name tuples
  */
 object TuplesHListExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/TypeCheckingExercises.scala
+++ b/src/main/scala/shapeless/TypeCheckingExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Try
 
@@ -29,7 +30,7 @@ import scala.util.Try
  * @param name type_checking
  */
 object TypeCheckingExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 

--- a/src/main/scala/shapeless/TypeSafeCastExercises.scala
+++ b/src/main/scala/shapeless/TypeSafeCastExercises.scala
@@ -6,7 +6,8 @@
 
 package shapelessex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 /** == Type safe cast ==
@@ -19,7 +20,7 @@ import shapeless._
  * @param name type_safe_cast
  */
 object TypeSafeCastExercises
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with org.scalaexercises.definitions.Section {
 


### PR DESCRIPTION
This PR updates ScalaTest dependency to version 3.1.0.